### PR TITLE
Potential fix for code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -5,6 +5,7 @@ import time
 from celery.result import AsyncResult
 from flask import Flask, flash, redirect, render_template, request
 from werkzeug.utils import secure_filename
+from urllib.parse import urlparse
 
 from api.utils import allowed_extensions
 from api.worker.initialization import celery_init_app
@@ -53,7 +54,10 @@ def load_and_transcribe() -> dict[str, object]:
             return redirect(request.url)
         if not allowed_extensions(file.filename, ALLOWED_EXTENSIONS):
             flash("File extension not allowed!")
-            return redirect(request.url)
+            target_url = request.url.replace('\\', '')
+            if not urlparse(target_url).netloc and not urlparse(target_url).scheme:
+                return redirect(target_url)
+            return redirect('/')
         # Ensure the filename is safe (no directory traversal)
         # and add timestamp to handle multiple save with same name
         filename = secure_filename(file.filename)


### PR DESCRIPTION
Potential fix for [https://github.com/matthieuml/whisper-api/security/code-scanning/3](https://github.com/matthieuml/whisper-api/security/code-scanning/3)

To fix the problem, we need to ensure that the URL used in the redirect is safe and does not allow open redirects. We can achieve this by validating the URL to ensure it does not contain an explicit host name or by maintaining a list of allowed URLs and checking against this list.

In this case, we will use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty. This ensures that the URL is a relative path and safe to redirect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
